### PR TITLE
Add dark mode and contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
           Carousel:
           <input type="checkbox" id="carousel-switch" />
         </label>
+        <button id="theme-toggle" class="theme-toggle" title="Toggle dark mode">🌙</button>
       </div>
     </div>
   </header>
@@ -125,6 +126,16 @@
     </div>
   </div>
 </section>
+
+    <section class="section" id="contact">
+      <h2 data-en="Contact" data-es="Contacto">Contact</h2>
+      <form id="contact-form">
+        <input type="text" id="name" name="name" placeholder="Name" required />
+        <input type="email" id="email" name="email" placeholder="Email" required />
+        <textarea id="message" name="message" placeholder="Message" rows="4" required></textarea>
+        <button type="submit">Send</button>
+      </form>
+    </section>
 
   </main>
 

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ document.querySelectorAll('.lang-button').forEach(button => {
 document.addEventListener('DOMContentLoaded', () => {
   const carouselSwitch = document.getElementById('carousel-switch');
   const container = document.querySelector('.experience-container');
+  const themeToggle = document.getElementById('theme-toggle');
+  const contactForm = document.getElementById('contact-form');
   let interval = null;
 
   function startCarousel() {
@@ -46,6 +48,28 @@ document.addEventListener('DOMContentLoaded', () => {
         container.classList.remove('carousel');
         stopCarousel();
       }
+    });
+  }
+
+  if (themeToggle) {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+      document.body.classList.add('dark-mode');
+      themeToggle.textContent = '☀️';
+    }
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+      const isDark = document.body.classList.contains('dark-mode');
+      themeToggle.textContent = isDark ? '☀️' : '🌙';
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+  }
+
+  if (contactForm) {
+    contactForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      alert('Message sent!');
+      contactForm.reset();
     });
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,19 @@ header h1 {
     gap: 10px;
 }
 
+.theme-toggle {
+    background: #00adb5;
+    border: none;
+    padding: 5px 10px;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 3px;
+}
+
+.theme-toggle:hover {
+    background: #007a83;
+}
+
 .lang-button {
     background: #00adb5;
     border: none;
@@ -172,6 +185,72 @@ footer {
     font-size: 0.9rem;
 }
 
+/* Contact form */
+#contact form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+#contact input,
+#contact textarea {
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+#contact button {
+    background: #00adb5;
+    color: #fff;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+#contact button:hover {
+    background: #007a83;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background: #121212;
+    color: #e0e0e0;
+}
+
+body.dark-mode header {
+    background: #1f1f1f;
+    border-bottom-color: #bb86fc;
+}
+
+body.dark-mode .section {
+    background: #1e1e1e;
+}
+
+body.dark-mode .skill {
+    background: #bb86fc;
+}
+
+body.dark-mode .lang-button.active {
+    background: #bb86fc;
+}
+
+body.dark-mode .theme-toggle {
+    background: #bb86fc;
+}
+
+body.dark-mode footer {
+    background: #1f1f1f;
+}
+
+body.dark-mode #contact input,
+body.dark-mode #contact textarea {
+    background: #2a2a2a;
+    color: #e0e0e0;
+    border-color: #555;
+}
+
 @media (min-width: 768px) {
     .experience-container:not(.carousel) .experience-item {
         flex: 1 1 calc(50% - 40px);
@@ -244,6 +323,4 @@ footer {
   .experience-right {
     padding-left: 0;
   }
-}
 
-}


### PR DESCRIPTION
## Summary
- add theme toggle in header
- add contact form section
- enhance script for theme and form handling
- style theme toggle, contact form and dark mode

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6865d19b41f4832caf338b90b4ac4687